### PR TITLE
Address issue #353, emit u8 padding then u64

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 - Remove `Builder::default` to force the specification of the C header file
   name.
+- No more overflow/crash when padding certain sized structures. (#353)
+- Structs with under 32 bytes of padding required will get a single u8 array
 
 ### Changed
 - Convert `float` and `double` to `f32` and `f64` by default (#348).

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -573,7 +573,6 @@ fn comp_to_rs(ctx: &mut GenCtx,
 
 fn gen_padding_fields(ctx: &mut GenCtx,
                       idx: usize,
-                      offset: usize,
                       padding_size: usize)
                       -> Vec<ast::StructField> {
     const MAX_ARRAY_CLONE_LEN: usize = 32; // impl<T: Copy> Clone for [T; 32]
@@ -584,26 +583,22 @@ fn gen_padding_fields(ctx: &mut GenCtx,
     let u8_ty = P(mk_ty(ctx, false, vec!["u8".to_owned()]));
     let mut size = padding_size;
 
-    let u64_padding_size = u64_size - (offset % u64_size);
+    // If we can do it with u8s, do it. Otherwise u8 to 8 byte boundary then use u64s
+    let u8_num = if size <= MAX_ARRAY_CLONE_LEN { size } else { size % u64_size };
+    size -= u8_num;
 
-    if (size - u64_padding_size) > u64_size && u64_padding_size != u64_size {
-        size -= u64_padding_size;
-    }
-
-    let mut fields = (0..(size / max_field_size))
-                         .map(|_| (&u64_ty, MAX_ARRAY_CLONE_LEN))
-                         .collect::<Vec<(&P<ast::Ty>, usize)>>();
-
-    let u64_num = (size % max_field_size) / u64_size;
-
-    if u64_num > 0 {
-        fields.push((&u64_ty, u64_num));
-    }
-
-    let u8_num = size % u64_size;
-
+    let mut fields = vec![];
     if u8_num > 0 {
         fields.push((&u8_ty, u8_num));
+    }
+
+    (0..(size / max_field_size))
+        .map(|_| (&u64_ty, MAX_ARRAY_CLONE_LEN))
+        .collect::<Vec<(&P<ast::Ty>, usize)>>();
+
+    let u64_num = (size % max_field_size) / u64_size;
+    if u64_num > 0 {
+        fields.push((&u64_ty, u64_num));
     }
 
     fields.iter()
@@ -648,8 +643,10 @@ fn cstruct_to_rs(ctx: &mut GenCtx,
     let mut can_derive_debug = derive_debug;
     let mut can_derive_clone = true;
 
+    let mut largest_member_alignment = 1;
+
     for m in &members {
-        debug!("convert field {} {:?}", m.name(), m);
+        debug!("convert field {} {:?}; offset {}", m.name(), m, offset);
 
         let (opt_rc_c, opt_rc_e, opt_f) = match *m {
             CompMember::Field(ref f) => (None, None, Some(f)),
@@ -659,11 +656,13 @@ fn cstruct_to_rs(ctx: &mut GenCtx,
             CompMember::EnumField(ref rc_e, ref f) => (None, Some(rc_e), Some(f)),
         };
 
+        if largest_member_alignment < m.layout().align { largest_member_alignment = m.layout().align; }
+
         if !layout.packed && m.layout().align != 0 && (offset % m.layout().align) != 0 {
             let padding_size = m.layout().align - (offset % m.layout().align);
 
             if padding_size > mem::size_of::<u64>() {
-                let mut padding_fields = gen_padding_fields(ctx, paddings, offset, padding_size);
+                let mut padding_fields = gen_padding_fields(ctx, paddings, padding_size);
 
                 fields.append(&mut padding_fields);
 
@@ -748,9 +747,11 @@ fn cstruct_to_rs(ctx: &mut GenCtx,
     }
 
     if offset < layout.size {
-        let mut padding_fields = gen_padding_fields(ctx, paddings, offset, layout.size - offset);
-
-        fields.append(&mut padding_fields);
+        // We only need to pad if the pad amount is more than the existing alignment
+        if layout.size - offset > largest_member_alignment {
+            let mut padding_fields = gen_padding_fields(ctx, paddings, layout.size - offset);
+            fields.append(&mut padding_fields);
+        }
     }
 
     let def = ast::ItemKind::Struct(ast::VariantData::Struct(fields, ast::DUMMY_NODE_ID),

--- a/tests/headers/struct_with_aligned_struct.h
+++ b/tests/headers/struct_with_aligned_struct.h
@@ -13,3 +13,16 @@ struct bar {
     int64_t b;
     struct foo foo;
 } __attribute__ ((aligned (64)));
+
+struct smaller_align {
+    int32_t x;
+    int64_t y;
+    int16_t z;
+} __attribute__ ((aligned (32)));
+
+struct implicit_pad {
+    int32_t a;
+    int32_t b;
+    int16_t c;
+};
+

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -450,8 +450,7 @@ fn struct_with_aligned_struct() {
             pub x: int32_t,
             pub y: int64_t,
             pub z: int16_t,
-            _bindgen_padding_0_: [u8; 6usize],
-            _bindgen_padding_1_: [u64; 5usize],
+            _bindgen_padding_0_: [u64; 5usize],
         }
         impl ::std::default::Default for foo {
             fn default() -> Self { unsafe { ::std::mem::zeroed() } }
@@ -468,6 +467,30 @@ fn struct_with_aligned_struct() {
         impl ::std::default::Default for bar {
             fn default() -> Self { unsafe { ::std::mem::zeroed() } }
         }
+		#[repr(C)]
+		#[derive(Copy, Clone)]
+		#[derive(Debug)]
+		pub struct smaller_align {
+			pub x: int32_t,
+			pub y: int64_t,
+			pub z: int16_t,
+			_bindgen_padding_0_: [u8; 14usize],
+		}
+		impl ::std::default::Default for smaller_align {
+			fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+		}
+		#[repr(C)]
+		#[derive(Copy, Clone)]
+		#[derive(Debug)]
+		pub struct implicit_pad {
+			pub a: int32_t,
+			pub b: int32_t,
+			pub c: int16_t,
+		}
+		impl ::std::default::Default for implicit_pad {
+			fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+		}
+
     ");
 
     pub type int16_t = ::std::os::raw::c_short;

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -450,7 +450,8 @@ fn struct_with_aligned_struct() {
             pub x: int32_t,
             pub y: int64_t,
             pub z: int16_t,
-            _bindgen_padding_0_: [u64; 5usize],
+            _bindgen_padding_0_: [u8; 6usize],
+            _bindgen_padding_1_: [u64; 5usize],
         }
         impl ::std::default::Default for foo {
             fn default() -> Self { unsafe { ::std::mem::zeroed() } }


### PR DESCRIPTION
Issue #353 
I think this does it. The output looks OK. For fields that have implicit padding, no padding is emitted (so { int32 a; char b } won't explicitly get the 3 bytes of padding it actually has.

I changed the order of the u64 and u8 padding as the calculation was wrong (it wouldn't take into account the alignment of the u64 array). Now it emits enough of a u8 array to get to an 8 byte boundary, then emits the u64 arrays as needed.

Also, if the total padding needed is under max array size (32) then just one padding array of u8s is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crabtw/rust-bindgen/364)
<!-- Reviewable:end -->
