### PR TITLE
generate constant array for vector and i128/u128

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -201,13 +201,14 @@ impl Type {
         unsafe { Type { x: clang_getPointeeType(self.x) } }
     }
 
-    // array
+    // array, complex or vector
     pub fn elem_type(&self) -> Type {
-        unsafe { Type { x: clang_getArrayElementType(self.x) } }
+        unsafe { Type { x: clang_getElementType(self.x) } }
     }
 
-    pub fn array_size(&self) -> usize {
-        unsafe { clang_getArraySize(self.x) as usize }
+    // array or vector
+    pub fn elem_num(&self) -> usize {
+        unsafe { clang_getNumElements(self.x) as usize }
     }
 
     // typedef

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -314,16 +314,10 @@ fn conv_ty(ctx: &mut ClangParserCtx, ty: &cx::Type, cursor: &Cursor) -> il::Type
         CXTypeKind::Typedef |
         CXTypeKind::Unexposed |
         CXTypeKind::Enum => conv_decl_ty(ctx, &ty.declaration()),
-        CXTypeKind::ConstantArray => {
+        CXTypeKind::ConstantArray | CXTypeKind::Vector => {
             TArray(Box::new(conv_ty(ctx, &ty.elem_type(), cursor)),
-                   ty.array_size(),
+                   ty.elem_num(),
                    layout)
-        }
-        CXTypeKind::Vector => {
-            log_err_warn(ctx,
-                         "Vector types are not supported, see https://github.com/crabtw/rust-bindgen/issues/356",
-                         true);
-            TVoid
         }
         CXTypeKind::Int128 | CXTypeKind::UInt128 => {
             log_err_warn(ctx,

--- a/tests/headers/i128.h
+++ b/tests/headers/i128.h
@@ -1,0 +1,2 @@
+typedef __int128 int128;
+typedef unsigned __int128 uint128;

--- a/tests/headers/vectors.h
+++ b/tests/headers/vectors.h
@@ -1,0 +1,4 @@
+typedef int __v4si __attribute__((__vector_size__(16)));
+typedef float __v4sf __attribute__((__vector_size__(16)));
+typedef int __m128i __attribute__((__vector_size__(16)));
+typedef unsigned int __v4su __attribute__((__vector_size__(16)));

--- a/tests/test_primitives.rs
+++ b/tests/test_primitives.rs
@@ -1,5 +1,5 @@
-use support::assert_bind_eq;
 use bindgen;
+use support::assert_bind_eq;
 
 #[test]
 fn unsigned() {
@@ -35,10 +35,24 @@ fn signed() {
 
 #[test]
 fn floats() {
-    assert_bind_eq(Default::default(), "headers/floats.h", "
+    assert_bind_eq(Default::default(),
+                   "headers/floats.h",
+                   "
     extern \"C\" {
         pub static mut f: f32;
         pub static mut d: f64;
     }
+    ");
+}
+
+#[test]
+fn vectors() {
+    assert_bind_eq(Default::default(),
+                   "headers/vectors.h",
+                   "
+    pub type __v4si = [::std::os::raw::c_int; 4usize];
+    pub type __v4sf = [f32; 4usize];
+    pub type __m128i = [::std::os::raw::c_int; 4usize];
+    pub type __v4su = [::std::os::raw::c_uint; 4usize];
     ");
 }

--- a/tests/test_primitives.rs
+++ b/tests/test_primitives.rs
@@ -56,3 +56,31 @@ fn vectors() {
     pub type __v4su = [::std::os::raw::c_uint; 4usize];
     ");
 }
+
+#[test]
+fn i128() {
+    assert_bind_eq(Default::default(),
+                   "headers/i128.h",
+                   "
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    #[derive(Debug)]
+    pub struct int128 {
+        pub hi: ::std::os::raw::c_longlong,
+        pub lo: ::std::os::raw::c_ulonglong,
+    }
+    impl ::std::default::Default for int128 {
+        fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    }
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    #[derive(Debug)]
+    pub struct uint128 {
+        pub hi: ::std::os::raw::c_ulonglong,
+        pub lo: ::std::os::raw::c_ulonglong,
+    }
+    impl ::std::default::Default for uint128 {
+        fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    }
+    ");
+}


### PR DESCRIPTION
fix #356, we need a placeholder to compile the header at least
