### PR TITLE
Bump clang-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "~0.3.6"
 # only for main, see https://github.com/rust-lang/cargo/issues/1982
 rustc-serialize = "~0.3.19"
 syntex_syntax = "~0.38.0"
-cexpr = "0.1.1"
+cexpr = "0.2.0"
 
 [dependencies.clippy]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 name = "bindgen"
 
 [dependencies]
-clang-sys = "~0.8"
+clang-sys = "~0.11.0"
 # only for main, see https://github.com/rust-lang/cargo/issues/1982
 docopt = "~0.6.80"
 # only for main, see https://github.com/rust-lang/cargo/issues/1982

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ cexpr = "0.1.1"
 
 [dependencies.clippy]
 optional = true
-version = "0.0.72"
+version = "0.0.95"
 
 [dev-dependencies]
 diff = "~0.1.9"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![][crates-version-shield]](https://crates.io/crates/bindgen)
 [![][crates-downloads-shield]](https://crates.io/crates/bindgen)
-[![][crates-license-shield]](https://github.com/crabtw/rust-bindgen/blob/master/LICENSE.txt)
-[![][travis-status-shield]](https://travis-ci.org/crabtw/rust-bindgen)
+[![][crates-license-shield]](https://github.com/Yamakaky/rust-bindgen/blob/master/LICENSE)
+[![][travis-status-shield]](https://travis-ci.org/Yamakaky/rust-bindgen)
 
 A native binding generator for the Rust language.
 
@@ -74,11 +74,11 @@ Options:
 
 ### Using a build script to generate bindings at compile time
 
-Due to a known issuewith `include!` https://github.com/rust-lang/rfcs/issues/752 when generating
-bindings in a build script and importing them with `include!` you'll want to wrap the bindings
+Due to a known issue with `include!` (https://github.com/rust-lang/rfcs/issues/752) when generating
+bindings in a build script and importing them with `include!`, you'll want to wrap the bindings
 in a module before writing them to a file to avoid triggering the issue with top-level
-attributes in `include!`. Some more discussion about this issue can be found here
-https://github.com/Yamakaky/rust-bindgen/issues/359 .
+attributes in `include!`. Some more discussion about this issue can be found
+[here](https://github.com/Yamakaky/rust-bindgen/issues/359).
 
 `Cargo.toml`
 ```rust
@@ -109,7 +109,7 @@ fn main(){
     // Wrap the bindings in a `pub mod` before writing bindgen's output
     file.write(format!("pub mod {} {{\n", "my_lib").as_bytes()).unwrap();
     file.write(generated_bindings.as_bytes()).unwrap();
-    file.write(b"}").unwrap(); 
+    file.write(b"}").unwrap();
 }
 ```
 
@@ -125,7 +125,6 @@ fn main() {
 [crates-version-shield]: https://img.shields.io/crates/v/bindgen.svg?style=flat-square
 [crates-downloads-shield]: https://img.shields.io/crates/d/bindgen.svg?style=flat-square
 [crates-license-shield]: https://img.shields.io/crates/l/bindgen.svg?style=flat-square
-[travis-status-shield]: https://img.shields.io/travis/crabtw/rust-bindgen/master.svg?label=travis&style=flat-square
+[travis-status-shield]: https://img.shields.io/travis/Yamakaky/rust-bindgen/master.svg?label=travis&style=flat-square
 
 [clay's bindgen]: https://github.com/jckarter/clay/blob/master/tools/bindgen.clay
-[issue 89]: https://github.com/yamakaky/rust-bindgen/issues/89

--- a/scripts/travis-before-install.sh
+++ b/scripts/travis-before-install.sh
@@ -1,3 +1,8 @@
+# Workaround for a Travis CI issue on OS X: https://github.com/travis-ci/travis-ci/issues/6522
+if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+    rvm get head || true
+fi
+
 set -e
 
 function llvm_version_triple() {

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -334,11 +334,12 @@ impl Into<CexprToken> for Token {
     fn into(self) -> CexprToken {
         CexprToken {
             kind:match self.kind {
-                CXTokenKind::Comment => CexprTokenKind::Comment,
-                CXTokenKind::Identifier => CexprTokenKind::Identifier,
-                CXTokenKind::Keyword => CexprTokenKind::Keyword,
-                CXTokenKind::Literal => CexprTokenKind::Literal,
-                CXTokenKind::Punctuation => CexprTokenKind::Punctuation,
+                CXToken_Comment => CexprTokenKind::Comment,
+                CXToken_Identifier => CexprTokenKind::Identifier,
+                CXToken_Keyword => CexprTokenKind::Keyword,
+                CXToken_Literal => CexprTokenKind::Literal,
+                CXToken_Punctuation => CexprTokenKind::Punctuation,
+                _ => panic!("invalid token kind: {:?}", self.kind),
             },
             raw:self.spelling.into_bytes().into_boxed_slice()
         }
@@ -383,7 +384,7 @@ impl TranslationUnit {
             clang_reparseTranslationUnit(self.x,
                                          c_unsaved.len() as c_uint,
                                          c_unsaved.as_mut_ptr(),
-                                         opts) == CXErrorCode::Success
+                                         opts) == CXError_Success
         }
     }
 
@@ -414,7 +415,7 @@ impl TranslationUnit {
 
     pub fn tokens(&self, cursor: &Cursor) -> Option<Vec<Token>> {
         let mut range = cursor.extent();
-        if cursor.kind()==CXCursorKind::MacroDefinition {
+        if cursor.kind()==CXCursor_MacroDefinition {
             range.end_int_data-=1; // bug observed in clang 3.5 ~ 3.8
         }
         let mut tokens = vec![];
@@ -504,5 +505,5 @@ pub fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
                  &format!("({:?} {} {:?}", c.kind(), c.spelling(), ct)[..]);
     c.visit(|s, _: &Cursor| ast_dump(s, depth + 1));
     print_indent(depth, ")");
-    CXChildVisitResult::Continue
+    CXChildVisit_Continue
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -285,7 +285,7 @@ pub fn gen_mod(options: &BindgenOptions,
     let mut fs = vec![];
     let mut vs = vec![];
     let mut gs = vec![];
-    for g in uniq_globs.into_iter() {
+    for g in uniq_globs {
         match g {
             GOther => {}
             GFunc(_) => fs.push(g),
@@ -331,7 +331,7 @@ pub fn gen_mod(options: &BindgenOptions,
         defs.push(mk_extern(&mut ctx, &options.links, vars, abi::Abi::C));
     }
 
-    for (abi, funcs) in funcs.into_iter() {
+    for (abi, funcs) in funcs {
         defs.push(mk_extern(&mut ctx, &options.links, funcs, abi));
     }
 
@@ -601,9 +601,6 @@ fn gen_padding_fields(ctx: &mut GenCtx,
     } else {
         // u64s only; subtract implicit 8-byte pad for alignment
         let size = padding_size - (padding_size % u64_size);
-        (0..(size / max_field_size))
-            .map(|_| (&u64_ty, MAX_ARRAY_CLONE_LEN))
-            .collect::<Vec<(&P<ast::Ty>, usize)>>();
 
         let u64_num = (size % max_field_size) / u64_size;
         if u64_num > 0 {
@@ -756,12 +753,10 @@ fn cstruct_to_rs(ctx: &mut GenCtx,
         offset += m.layout().size as usize;
     }
 
-    if offset < layout.size {
-        // We only need to pad if the pad amount is more than the existing alignment
-        if layout.size - offset > largest_member_alignment {
-            let mut padding_fields = gen_padding_fields(ctx, paddings, layout.size - offset);
-            fields.append(&mut padding_fields);
-        }
+    // We only need to pad if the pad amount is more than the existing alignment
+    if offset < layout.size && layout.size - offset > largest_member_alignment {
+        let mut padding_fields = gen_padding_fields(ctx, paddings, layout.size - offset);
+        fields.append(&mut padding_fields);
     }
 
     let def = ast::ItemKind::Struct(ast::VariantData::Struct(fields, ast::DUMMY_NODE_ID),
@@ -1188,7 +1183,7 @@ fn gen_comp_methods(ctx: &mut GenCtx,
 
     let mut offset = data_offset;
     let mut methods = vec![];
-    for m in members.into_iter() {
+    for m in members {
         let advance_by = match *m {
             CompMember::Field(ref f) => {
                 methods.extend(mk_field_method(ctx, f, offset).into_iter());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -368,16 +368,14 @@ impl MacroTypes {
                     } else {
                         self.t_u64
                     }
+                } else if i>=(::std::i8::MIN as i64) {
+                    self.t_i8
+                } else if i>=(::std::i16::MIN as i64) {
+                    self.t_i16
+                } else if i>=(::std::i32::MIN as i64) {
+                    self.t_i32
                 } else {
-                    if i>=(::std::i8::MIN as i64) {
-                        self.t_i8
-                    } else if i>=(::std::i16::MIN as i64) {
-                        self.t_i16
-                    } else if i>=(::std::i32::MIN as i64) {
-                        self.t_i32
-                    } else {
-                        self.t_i64
-                    }
+                    self.t_i64
                 };
                 Some((Type::TInt(kind,Layout::default()),Some(i)))
             },

--- a/src/types.rs
+++ b/src/types.rs
@@ -224,18 +224,8 @@ pub enum IKind {
 impl IKind {
     pub fn is_signed(self) -> bool {
         match self {
-            IBool => false,
-            ISChar => true,
-            IUChar => false,
-            IShort => true,
-            IUShort => false,
-            IInt => true,
-            IUInt => false,
-            ILong => true,
-            IULong => false,
-            ILongLong => true,
-            IULongLong => false,
-            IWChar => false,
+            IBool | IUChar | IWChar | IUShort | IUInt | IULong | IULongLong => false,
+            ISChar | IShort | IInt | ILong | ILongLong => true,
         }
     }
 }


### PR DESCRIPTION
I had to make breaking changes in `clang-sys` to avoid undefined behavior (KyleMayes/clang-sys#42) that led to crashes with `libclang` 3.9. All of the enums have been changed to constants.

This pull requests deals with the fallout from those changes (and updates the README.md and fixes some clippy warnings).

However, there is still the outstanding issue of `CXType_Elaborated`, which was added to the `CXTypeKind` enum in `libclang` 3.9. Some C types are now reported as `CXType_Elaborated`, which breaks this library when using `libclang` 3.9 (the primary culprit seems to be typedefs). I tried to fix this myself but I don't understand how this library works, so I eventually gave up.